### PR TITLE
Fix: Add read contents permission

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -2,7 +2,8 @@ name: Deploy to Dev Environment
 
 permissions:
   id-token: write
-  
+  contents: read
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -2,6 +2,7 @@ name: Deploy to Production Environment
 
 permissions:
   id-token: write
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This PR adds `contents: read` permission to both `deploy` workflows. This was done proactively to ensure that we don't run into any future problems accessing repo contents. 