### PR TITLE
dev: fix auto-deploy on commits to main branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,4 +21,4 @@ jobs:
       - uses: ./.github/actions/deploy
         with:
           aws-role: ${{ secrets.AWS_ROLE_ARN }}
-          environment: ${{ inputs.environment }}
+          environment: ${{ inputs.environment || 'dev' }}


### PR DESCRIPTION
The default value of this workflow input is `dev`, however, inputs are only available in the first place if the workflow was triggered by manual dispatch (and not by a push to the main branch). Oops.