### PR TITLE
dev: upgrade Prettier from v2 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
-      - run: npm run prettier:check
+      - run: npx --no prettier --check .
 
   test:
     name: Tests

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,1 @@
+{ "proseWrap": "always", "trailingComma": "es5" }

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,30 +5,30 @@
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance, race,
-religion, or sexual identity and orientation.
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
+- The use of sexualized language or imagery and unwelcome sexual attention or
   advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities
@@ -37,11 +37,11 @@ Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
 
 ## Scope
 
@@ -55,11 +55,11 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at developer@mbta.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported by contacting the project team at developer@mbta.com. All complaints
+will be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. The project team is obligated to
+maintain confidentiality with regard to the reporter of an incident. Further
+details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
@@ -67,7 +67,8 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ The contact flow is included here as hotline_prod.json/hotline_dev.json
 
 <img src="/hotline_dev.png" alt="Hotline IVR"/>
 
-When making changes in amazon connect make sure to export and update the json file in the git repo.
+When making changes in amazon connect make sure to export and update the json
+file in the git repo.
 
 ## AWS Lambda
 
-The lambda is called whenever a call is made to the elevator hotline. It in turn calls the mbta api to get the current alerts and then the affected stations.  It then builds a payload broken up by line for the ivr.
+The lambda is called whenever a call is made to the elevator hotline. It in turn
+calls the mbta api to get the current alerts and then the affected stations. It
+then builds a payload broken up by line for the ivr.
 
 To run the lambda locally, put an api key in .env.override as API_KEY
 
@@ -23,7 +26,7 @@ npm install
 ```
 
 then run
+
 ```
 npm run local
 ```
-

--- a/hotline_dev.json
+++ b/hotline_dev.json
@@ -1,1 +1,653 @@
-{"modules":[{"id":"6c745c27-6c4d-4eb1-87fa-6986c7e785b7","type":"SetLoggingBehavior","branches":[{"condition":"Success","transition":"378e525e-29ef-471b-b0a1-14b69e61f41e"}],"parameters":[{"name":"LoggingBehavior","value":"Enable"}],"metadata":{"position":{"x":141,"y":21.09805800546067}}},{"id":"a93e74a8-355c-4b7c-9e86-a69f889095ce","type":"SetAttributes","branches":[{"condition":"Success","transition":"864985be-4aa7-4c5f-ba40-638da53f09d0"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Attribute","value":"line_choice_log$.Attributes.line_choice","key":"line_choice_log","namespace":"User Defined"}],"metadata":{"position":{"x":1261,"y":71.09805800546067}}},{"id":"93ec5f16-a5cb-49f5-9f1d-fcff0642b856","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"silver","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":1872,"y":435.5},"conditionMetadata":[{"id":"b19de7a8-e499-4397-909b-a220bdbfb6bb","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"ff737200-4608-467e-95e6-6d2d5a3f116d","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"commuter","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":1870,"y":718.0980580054606},"conditionMetadata":[{"id":"e26d55a8-ed97-4e20-b6c7-3169d53ebaa8","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"26e30010-50fb-42df-a6b2-ea51b62c38a5","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"red","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":2223,"y":15.5},"conditionMetadata":[{"id":"5b9bb06e-3492-4ebf-a972-25f9a09a0073","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"b8839179-7ddc-4e4c-befc-f2b356445738","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"orange","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":2227,"y":287.5},"conditionMetadata":[{"id":"dc08081b-bccc-47b4-8df5-62a0d383f21a","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"33b1deb0-2bec-40b5-b5e3-502b292e94ba","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"green","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":2228,"y":555.5},"conditionMetadata":[{"id":"c92b297d-0c7a-41d4-8ca8-7ce2b600df81","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"e3ef239d-ad61-463e-bbd8-b14c34362a88","type":"Loop","branches":[{"condition":"Looping","transition":"864985be-4aa7-4c5f-ba40-638da53f09d0"},{"condition":"Complete","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"LoopCount","value":"10"}],"metadata":{"position":{"x":1307,"y":696.3029243487802},"useDynamic":false}},{"id":"864985be-4aa7-4c5f-ba40-638da53f09d0","type":"CheckAttribute","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"1","transition":"26e30010-50fb-42df-a6b2-ea51b62c38a5"},{"condition":"Evaluate","conditionType":"Equals","conditionValue":"2","transition":"b8839179-7ddc-4e4c-befc-f2b356445738"},{"condition":"Evaluate","conditionType":"Equals","conditionValue":"3","transition":"33b1deb0-2bec-40b5-b5e3-502b292e94ba"},{"condition":"Evaluate","conditionType":"Equals","conditionValue":"4","transition":"43bba9b9-fddb-4fb7-acb2-0575ac413964"},{"condition":"Evaluate","conditionType":"Equals","conditionValue":"5","transition":"93ec5f16-a5cb-49f5-9f1d-fcff0642b856"},{"condition":"Evaluate","conditionType":"Equals","conditionValue":"6","transition":"ff737200-4608-467e-95e6-6d2d5a3f116d"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Attribute","value":"line_choice"},{"name":"Namespace","value":"User Defined"}],"metadata":{"position":{"x":1567,"y":21.5},"conditionMetadata":[{"id":"2f4f99de-b5c1-4a4e-9606-8952f0ad5a69","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"1"},{"id":"95f319d8-a36a-4dcf-a24b-6e19e4f7045d","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"2"},{"id":"62522a3e-38fa-4a4d-9092-212156c7be24","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"3"},{"id":"2bbe7e22-aa1d-4ce4-9041-390221369d76","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"4"},{"id":"731f6982-7430-4e3f-8756-6bd6964cd1cd","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"5"},{"id":"ab3222af-07c8-4bf2-a4a1-dd9761974452","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"6"}]}},{"id":"43bba9b9-fddb-4fb7-acb2-0575ac413964","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"blue","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":2222,"y":834.5},"conditionMetadata":[{"id":"5c44f6e3-3415-45b9-8586-39858a0cdd4e","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"378e525e-29ef-471b-b0a1-14b69e61f41e","type":"InvokeExternalResource","branches":[{"condition":"Success","transition":"88b8dfd5-2a0c-48b9-9004-781705cdd951"},{"condition":"Error","transition":"a7e9ad86-446d-4297-bee5-dad34db002a5"}],"parameters":[{"name":"FunctionArn","value":"arn:aws:lambda:us-east-1:434035161053:function:elevator-hotline-dev","namespace":null},{"name":"TimeLimit","value":"3"}],"metadata":{"position":{"x":65,"y":188.09805800546067},"dynamicMetadata":{},"useDynamic":false},"target":"Lambda"},{"id":"a7e9ad86-446d-4297-bee5-dad34db002a5","type":"PlayPrompt","branches":[{"condition":"Success","transition":"a4f6b0d8-e03d-43fc-b000-75e52e028b70"}],"parameters":[{"name":"Text","value":"Hello, you have reached the MBTA's elevator and escalator out-of-service update line. \n\nWe are currently experiencing some technical difficulties, and are now attempting to transfer you to a representative at number 617-222-3200","namespace":null},{"name":"TextToSpeechType","value":"text"}],"metadata":{"position":{"x":447,"y":256},"useDynamic":false}},{"id":"52e502c3-221e-4fad-a4db-9892481f2116","type":"Disconnect","branches":[],"parameters":[],"metadata":{"position":{"x":446,"y":1012.5}}},{"id":"a4f6b0d8-e03d-43fc-b000-75e52e028b70","type":"Transfer","branches":[{"condition":"Success","transition":"b07e1f8f-a47b-4636-abe9-5d0933c28abd"},{"condition":"CallFailure","transition":"b07e1f8f-a47b-4636-abe9-5d0933c28abd"},{"condition":"Timeout","transition":"b07e1f8f-a47b-4636-abe9-5d0933c28abd"},{"condition":"Error","transition":"b07e1f8f-a47b-4636-abe9-5d0933c28abd"}],"parameters":[{"name":"TimeLimit","value":"30"},{"name":"BlindTransfer","value":false},{"name":"PhoneNumber","value":"+1617-222-3200"}],"metadata":{"position":{"x":405,"y":451.5},"CountryCode":"us"},"target":"PhoneNumber"},{"id":"025df89c-5036-4627-b7a0-0ba3e999b8c2","type":"Loop","branches":[{"condition":"Looping","transition":"51aed40c-bdb7-4046-9022-df97d8f918a7"},{"condition":"Complete","transition":"b07e1f8f-a47b-4636-abe9-5d0933c28abd"}],"parameters":[{"name":"LoopCount","value":"10"}],"metadata":{"position":{"x":2362,"y":1280.0980580054606},"useDynamic":false}},{"id":"b07e1f8f-a47b-4636-abe9-5d0933c28abd","type":"PlayPrompt","branches":[{"condition":"Success","transition":"52e502c3-221e-4fad-a4db-9892481f2116"}],"parameters":[{"name":"Text","value":"Thank you for calling. Goodbye.","namespace":null},{"name":"TextToSpeechType","value":"text"}],"metadata":{"position":{"x":320,"y":792.5},"useDynamic":false}},{"id":"7a68c1c0-f93e-4322-afcb-a3ac4057f254","type":"SetAttributes","branches":[{"condition":"Success","transition":"a93e74a8-355c-4b7c-9e86-a69f889095ce"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Attribute","value":"Stored customer input","key":"line_choice","namespace":"System"}],"metadata":{"position":{"x":984,"y":50.09805800546067}}},{"id":"51aed40c-bdb7-4046-9022-df97d8f918a7","type":"StoreUserInput","branches":[{"condition":"Success","transition":"7a68c1c0-f93e-4322-afcb-a3ac4057f254"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"For outages affecting the red line, press one.\nFor outages affecting the orange line, press two.\nFor outages affecting the green line, press three.\nFor outages affecting the blue line, press four.\nFor outages affecting the silver line, press five.\nFor outages affecting the commuter rail, press six.\nPress 9 to repeat the previous alerts or 0 to return to the main menu at any time.","namespace":null},{"name":"TextToSpeechType","value":"text"},{"name":"CustomerInputType","value":"Custom"},{"name":"Timeout","value":"6"},{"name":"MaxDigits","value":1},{"name":"EncryptEntry","value":false},{"name":"DisableCancel","value":"false"}],"metadata":{"position":{"x":763,"y":972.0980580054606},"useDynamic":false,"useDynamicForEncryptionKeys":true,"useDynamicForTerminatorDigits":false,"countryCodePrefix":"+1"}},{"id":"88b8dfd5-2a0c-48b9-9004-781705cdd951","type":"CheckAttribute","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"200","transition":"7ec8cd24-a8a2-44bf-a130-d0d9e33ee010"},{"condition":"NoMatch","transition":"a7e9ad86-446d-4297-bee5-dad34db002a5"}],"parameters":[{"name":"Attribute","value":"status"},{"name":"Namespace","value":"External"}],"metadata":{"position":{"x":420,"y":31.098058005460672},"conditionMetadata":[{"id":"481de0d7-d15e-495c-a0b2-0970032747fc","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"200"}]}},{"id":"7ec8cd24-a8a2-44bf-a130-d0d9e33ee010","type":"StoreUserInput","branches":[{"condition":"Success","transition":"7a68c1c0-f93e-4322-afcb-a3ac4057f254"},{"condition":"Error","transition":"51aed40c-bdb7-4046-9022-df97d8f918a7"}],"parameters":[{"name":"Text","value":"Hello, you have reached the MBTA's elevator and escalator out-of-service update line. his recording is updated in real time.\n\nFor outages affecting the red line, press one.\nFor outages affecting the orange line, press two.\nFor outages affecting the green line, press three.\nFor outages affecting the blue line, press four.\nFor outages affecting the silver line, press five.\nFor outages affecting the commuter rail, press six.\nPress 9 to repeat the previous alerts or 0 to return to the main menu at any time.","namespace":null},{"name":"TextToSpeechType","value":"text"},{"name":"CustomerInputType","value":"Custom"},{"name":"Timeout","value":"6"},{"name":"MaxDigits","value":1},{"name":"EncryptEntry","value":false},{"name":"DisableCancel","value":"false"}],"metadata":{"position":{"x":681,"y":28.098058005460672},"useDynamic":false,"useDynamicForEncryptionKeys":true,"useDynamicForTerminatorDigits":false,"countryCodePrefix":"+1"}}],"version":"1","type":"contactFlow","start":"6c745c27-6c4d-4eb1-87fa-6986c7e785b7","metadata":{"entryPointPosition":{"x":15.500339628716162,"y":18.59805800546067},"snapToGrid":false,"name":"MBTA Elevator Hotline","description":null,"type":"contactFlow","status":"published","hash":"ded463cabbad67cf442d2f570907e4b20e02ef66f138f02af996ac7753e9ae9f"}}
+{
+  "modules": [
+    {
+      "id": "6c745c27-6c4d-4eb1-87fa-6986c7e785b7",
+      "type": "SetLoggingBehavior",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "378e525e-29ef-471b-b0a1-14b69e61f41e"
+        }
+      ],
+      "parameters": [{ "name": "LoggingBehavior", "value": "Enable" }],
+      "metadata": { "position": { "x": 141, "y": 21.09805800546067 } }
+    },
+    {
+      "id": "a93e74a8-355c-4b7c-9e86-a69f889095ce",
+      "type": "SetAttributes",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "864985be-4aa7-4c5f-ba40-638da53f09d0"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Attribute",
+          "value": "line_choice_log$.Attributes.line_choice",
+          "key": "line_choice_log",
+          "namespace": "User Defined"
+        }
+      ],
+      "metadata": { "position": { "x": 1261, "y": 71.09805800546067 } }
+    },
+    {
+      "id": "93ec5f16-a5cb-49f5-9f1d-fcff0642b856",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "silver", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 1872, "y": 435.5 },
+        "conditionMetadata": [
+          { "id": "b19de7a8-e499-4397-909b-a220bdbfb6bb", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "ff737200-4608-467e-95e6-6d2d5a3f116d",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "commuter", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 1870, "y": 718.0980580054606 },
+        "conditionMetadata": [
+          { "id": "e26d55a8-ed97-4e20-b6c7-3169d53ebaa8", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "26e30010-50fb-42df-a6b2-ea51b62c38a5",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "red", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 2223, "y": 15.5 },
+        "conditionMetadata": [
+          { "id": "5b9bb06e-3492-4ebf-a972-25f9a09a0073", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "b8839179-7ddc-4e4c-befc-f2b356445738",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "orange", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 2227, "y": 287.5 },
+        "conditionMetadata": [
+          { "id": "dc08081b-bccc-47b4-8df5-62a0d383f21a", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "33b1deb0-2bec-40b5-b5e3-502b292e94ba",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "green", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 2228, "y": 555.5 },
+        "conditionMetadata": [
+          { "id": "c92b297d-0c7a-41d4-8ca8-7ce2b600df81", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "e3ef239d-ad61-463e-bbd8-b14c34362a88",
+      "type": "Loop",
+      "branches": [
+        {
+          "condition": "Looping",
+          "transition": "864985be-4aa7-4c5f-ba40-638da53f09d0"
+        },
+        {
+          "condition": "Complete",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [{ "name": "LoopCount", "value": "10" }],
+      "metadata": {
+        "position": { "x": 1307, "y": 696.3029243487802 },
+        "useDynamic": false
+      }
+    },
+    {
+      "id": "864985be-4aa7-4c5f-ba40-638da53f09d0",
+      "type": "CheckAttribute",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "1",
+          "transition": "26e30010-50fb-42df-a6b2-ea51b62c38a5"
+        },
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "2",
+          "transition": "b8839179-7ddc-4e4c-befc-f2b356445738"
+        },
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "3",
+          "transition": "33b1deb0-2bec-40b5-b5e3-502b292e94ba"
+        },
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "4",
+          "transition": "43bba9b9-fddb-4fb7-acb2-0575ac413964"
+        },
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "5",
+          "transition": "93ec5f16-a5cb-49f5-9f1d-fcff0642b856"
+        },
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "6",
+          "transition": "ff737200-4608-467e-95e6-6d2d5a3f116d"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Attribute", "value": "line_choice" },
+        { "name": "Namespace", "value": "User Defined" }
+      ],
+      "metadata": {
+        "position": { "x": 1567, "y": 21.5 },
+        "conditionMetadata": [
+          {
+            "id": "2f4f99de-b5c1-4a4e-9606-8952f0ad5a69",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "1"
+          },
+          {
+            "id": "95f319d8-a36a-4dcf-a24b-6e19e4f7045d",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "2"
+          },
+          {
+            "id": "62522a3e-38fa-4a4d-9092-212156c7be24",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "3"
+          },
+          {
+            "id": "2bbe7e22-aa1d-4ce4-9041-390221369d76",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "4"
+          },
+          {
+            "id": "731f6982-7430-4e3f-8756-6bd6964cd1cd",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "5"
+          },
+          {
+            "id": "ab3222af-07c8-4bf2-a4a1-dd9761974452",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "6"
+          }
+        ]
+      }
+    },
+    {
+      "id": "43bba9b9-fddb-4fb7-acb2-0575ac413964",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "blue", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 2222, "y": 834.5 },
+        "conditionMetadata": [
+          { "id": "5c44f6e3-3415-45b9-8586-39858a0cdd4e", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "378e525e-29ef-471b-b0a1-14b69e61f41e",
+      "type": "InvokeExternalResource",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "88b8dfd5-2a0c-48b9-9004-781705cdd951"
+        },
+        {
+          "condition": "Error",
+          "transition": "a7e9ad86-446d-4297-bee5-dad34db002a5"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "FunctionArn",
+          "value": "arn:aws:lambda:us-east-1:434035161053:function:elevator-hotline-dev",
+          "namespace": null
+        },
+        { "name": "TimeLimit", "value": "3" }
+      ],
+      "metadata": {
+        "position": { "x": 65, "y": 188.09805800546067 },
+        "dynamicMetadata": {},
+        "useDynamic": false
+      },
+      "target": "Lambda"
+    },
+    {
+      "id": "a7e9ad86-446d-4297-bee5-dad34db002a5",
+      "type": "PlayPrompt",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "a4f6b0d8-e03d-43fc-b000-75e52e028b70"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Text",
+          "value": "Hello, you have reached the MBTA's elevator and escalator out-of-service update line. \n\nWe are currently experiencing some technical difficulties, and are now attempting to transfer you to a representative at number 617-222-3200",
+          "namespace": null
+        },
+        { "name": "TextToSpeechType", "value": "text" }
+      ],
+      "metadata": { "position": { "x": 447, "y": 256 }, "useDynamic": false }
+    },
+    {
+      "id": "52e502c3-221e-4fad-a4db-9892481f2116",
+      "type": "Disconnect",
+      "branches": [],
+      "parameters": [],
+      "metadata": { "position": { "x": 446, "y": 1012.5 } }
+    },
+    {
+      "id": "a4f6b0d8-e03d-43fc-b000-75e52e028b70",
+      "type": "Transfer",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "b07e1f8f-a47b-4636-abe9-5d0933c28abd"
+        },
+        {
+          "condition": "CallFailure",
+          "transition": "b07e1f8f-a47b-4636-abe9-5d0933c28abd"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "b07e1f8f-a47b-4636-abe9-5d0933c28abd"
+        },
+        {
+          "condition": "Error",
+          "transition": "b07e1f8f-a47b-4636-abe9-5d0933c28abd"
+        }
+      ],
+      "parameters": [
+        { "name": "TimeLimit", "value": "30" },
+        { "name": "BlindTransfer", "value": false },
+        { "name": "PhoneNumber", "value": "+1617-222-3200" }
+      ],
+      "metadata": { "position": { "x": 405, "y": 451.5 }, "CountryCode": "us" },
+      "target": "PhoneNumber"
+    },
+    {
+      "id": "025df89c-5036-4627-b7a0-0ba3e999b8c2",
+      "type": "Loop",
+      "branches": [
+        {
+          "condition": "Looping",
+          "transition": "51aed40c-bdb7-4046-9022-df97d8f918a7"
+        },
+        {
+          "condition": "Complete",
+          "transition": "b07e1f8f-a47b-4636-abe9-5d0933c28abd"
+        }
+      ],
+      "parameters": [{ "name": "LoopCount", "value": "10" }],
+      "metadata": {
+        "position": { "x": 2362, "y": 1280.0980580054606 },
+        "useDynamic": false
+      }
+    },
+    {
+      "id": "b07e1f8f-a47b-4636-abe9-5d0933c28abd",
+      "type": "PlayPrompt",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "52e502c3-221e-4fad-a4db-9892481f2116"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Text",
+          "value": "Thank you for calling. Goodbye.",
+          "namespace": null
+        },
+        { "name": "TextToSpeechType", "value": "text" }
+      ],
+      "metadata": { "position": { "x": 320, "y": 792.5 }, "useDynamic": false }
+    },
+    {
+      "id": "7a68c1c0-f93e-4322-afcb-a3ac4057f254",
+      "type": "SetAttributes",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "a93e74a8-355c-4b7c-9e86-a69f889095ce"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Attribute",
+          "value": "Stored customer input",
+          "key": "line_choice",
+          "namespace": "System"
+        }
+      ],
+      "metadata": { "position": { "x": 984, "y": 50.09805800546067 } }
+    },
+    {
+      "id": "51aed40c-bdb7-4046-9022-df97d8f918a7",
+      "type": "StoreUserInput",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "7a68c1c0-f93e-4322-afcb-a3ac4057f254"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Text",
+          "value": "For outages affecting the red line, press one.\nFor outages affecting the orange line, press two.\nFor outages affecting the green line, press three.\nFor outages affecting the blue line, press four.\nFor outages affecting the silver line, press five.\nFor outages affecting the commuter rail, press six.\nPress 9 to repeat the previous alerts or 0 to return to the main menu at any time.",
+          "namespace": null
+        },
+        { "name": "TextToSpeechType", "value": "text" },
+        { "name": "CustomerInputType", "value": "Custom" },
+        { "name": "Timeout", "value": "6" },
+        { "name": "MaxDigits", "value": 1 },
+        { "name": "EncryptEntry", "value": false },
+        { "name": "DisableCancel", "value": "false" }
+      ],
+      "metadata": {
+        "position": { "x": 763, "y": 972.0980580054606 },
+        "useDynamic": false,
+        "useDynamicForEncryptionKeys": true,
+        "useDynamicForTerminatorDigits": false,
+        "countryCodePrefix": "+1"
+      }
+    },
+    {
+      "id": "88b8dfd5-2a0c-48b9-9004-781705cdd951",
+      "type": "CheckAttribute",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "200",
+          "transition": "7ec8cd24-a8a2-44bf-a130-d0d9e33ee010"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "a7e9ad86-446d-4297-bee5-dad34db002a5"
+        }
+      ],
+      "parameters": [
+        { "name": "Attribute", "value": "status" },
+        { "name": "Namespace", "value": "External" }
+      ],
+      "metadata": {
+        "position": { "x": 420, "y": 31.098058005460672 },
+        "conditionMetadata": [
+          {
+            "id": "481de0d7-d15e-495c-a0b2-0970032747fc",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "200"
+          }
+        ]
+      }
+    },
+    {
+      "id": "7ec8cd24-a8a2-44bf-a130-d0d9e33ee010",
+      "type": "StoreUserInput",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "7a68c1c0-f93e-4322-afcb-a3ac4057f254"
+        },
+        {
+          "condition": "Error",
+          "transition": "51aed40c-bdb7-4046-9022-df97d8f918a7"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Text",
+          "value": "Hello, you have reached the MBTA's elevator and escalator out-of-service update line. his recording is updated in real time.\n\nFor outages affecting the red line, press one.\nFor outages affecting the orange line, press two.\nFor outages affecting the green line, press three.\nFor outages affecting the blue line, press four.\nFor outages affecting the silver line, press five.\nFor outages affecting the commuter rail, press six.\nPress 9 to repeat the previous alerts or 0 to return to the main menu at any time.",
+          "namespace": null
+        },
+        { "name": "TextToSpeechType", "value": "text" },
+        { "name": "CustomerInputType", "value": "Custom" },
+        { "name": "Timeout", "value": "6" },
+        { "name": "MaxDigits", "value": 1 },
+        { "name": "EncryptEntry", "value": false },
+        { "name": "DisableCancel", "value": "false" }
+      ],
+      "metadata": {
+        "position": { "x": 681, "y": 28.098058005460672 },
+        "useDynamic": false,
+        "useDynamicForEncryptionKeys": true,
+        "useDynamicForTerminatorDigits": false,
+        "countryCodePrefix": "+1"
+      }
+    }
+  ],
+  "version": "1",
+  "type": "contactFlow",
+  "start": "6c745c27-6c4d-4eb1-87fa-6986c7e785b7",
+  "metadata": {
+    "entryPointPosition": { "x": 15.500339628716162, "y": 18.59805800546067 },
+    "snapToGrid": false,
+    "name": "MBTA Elevator Hotline",
+    "description": null,
+    "type": "contactFlow",
+    "status": "published",
+    "hash": "ded463cabbad67cf442d2f570907e4b20e02ef66f138f02af996ac7753e9ae9f"
+  }
+}

--- a/hotline_prod.json
+++ b/hotline_prod.json
@@ -1,1 +1,652 @@
-{"modules":[{"id":"6c745c27-6c4d-4eb1-87fa-6986c7e785b7","type":"SetLoggingBehavior","branches":[{"condition":"Success","transition":"378e525e-29ef-471b-b0a1-14b69e61f41e"}],"parameters":[{"name":"LoggingBehavior","value":"Enable"}],"metadata":{"position":{"x":141,"y":20.59805800546067}}},{"id":"52e502c3-221e-4fad-a4db-9892481f2116","type":"Disconnect","branches":[],"parameters":[],"metadata":{"position":{"x":446,"y":1012}}},{"id":"b07e1f8f-a47b-4636-abe9-5d0933c28abd","type":"PlayPrompt","branches":[{"condition":"Success","transition":"52e502c3-221e-4fad-a4db-9892481f2116"}],"parameters":[{"name":"Text","value":"Thank you for calling. Goodbye.","namespace":null},{"name":"TextToSpeechType","value":"text"}],"metadata":{"position":{"x":320,"y":792},"useDynamic":false}},{"id":"a93e74a8-355c-4b7c-9e86-a69f889095ce","type":"SetAttributes","branches":[{"condition":"Success","transition":"864985be-4aa7-4c5f-ba40-638da53f09d0"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Attribute","value":"line_choice_log$.Attributes.line_choice","key":"line_choice_log","namespace":"User Defined"}],"metadata":{"position":{"x":1261,"y":70.59805800546067}}},{"id":"ff737200-4608-467e-95e6-6d2d5a3f116d","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"commuter","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":1870,"y":717.5980580054606},"conditionMetadata":[{"id":"379751ca-c0e6-4dbf-84b3-7f17ae05e359","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"b8839179-7ddc-4e4c-befc-f2b356445738","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"orange","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":2227,"y":287},"conditionMetadata":[{"id":"feddca92-66bb-46e2-a45e-5ebd6f80f6e8","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"33b1deb0-2bec-40b5-b5e3-502b292e94ba","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"green","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":2228,"y":555},"conditionMetadata":[{"id":"bd3be66e-7634-40ef-92bc-7b1b3ba8e4df","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"43bba9b9-fddb-4fb7-acb2-0575ac413964","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"blue","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":2222,"y":834},"conditionMetadata":[{"id":"2b5a9690-6267-446e-942f-70ae71c50d8e","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"26e30010-50fb-42df-a6b2-ea51b62c38a5","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"red","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":2223,"y":15.5},"conditionMetadata":[{"id":"e8eb793b-ca99-42ec-83ae-d3c73bae21c6","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"e3ef239d-ad61-463e-bbd8-b14c34362a88","type":"Loop","branches":[{"condition":"Looping","transition":"864985be-4aa7-4c5f-ba40-638da53f09d0"},{"condition":"Complete","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"LoopCount","value":"10"}],"metadata":{"position":{"x":1307,"y":695.8029243487802},"useDynamic":false}},{"id":"864985be-4aa7-4c5f-ba40-638da53f09d0","type":"CheckAttribute","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"1","transition":"26e30010-50fb-42df-a6b2-ea51b62c38a5"},{"condition":"Evaluate","conditionType":"Equals","conditionValue":"2","transition":"b8839179-7ddc-4e4c-befc-f2b356445738"},{"condition":"Evaluate","conditionType":"Equals","conditionValue":"3","transition":"33b1deb0-2bec-40b5-b5e3-502b292e94ba"},{"condition":"Evaluate","conditionType":"Equals","conditionValue":"4","transition":"43bba9b9-fddb-4fb7-acb2-0575ac413964"},{"condition":"Evaluate","conditionType":"Equals","conditionValue":"5","transition":"93ec5f16-a5cb-49f5-9f1d-fcff0642b856"},{"condition":"Evaluate","conditionType":"Equals","conditionValue":"6","transition":"ff737200-4608-467e-95e6-6d2d5a3f116d"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Attribute","value":"line_choice"},{"name":"Namespace","value":"User Defined"}],"metadata":{"position":{"x":1567,"y":21},"conditionMetadata":[{"id":"bfc45702-3ba3-4c93-8a58-0996654f2945","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"1"},{"id":"56644aa9-04ba-4523-806e-b347385d1a6f","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"2"},{"id":"5ed0bc7b-d7af-4f5c-815a-6bf7fe926c10","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"3"},{"id":"aa505e28-96db-43a3-8b44-12070cecfe37","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"4"},{"id":"30e8ce40-66ea-405f-8a9e-ed834249ddf2","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"5"},{"id":"b5a5cd72-34fa-4c1a-80bf-09c1988702b0","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"6"}]}},{"id":"93ec5f16-a5cb-49f5-9f1d-fcff0642b856","type":"GetUserInput","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"9","transition":"e3ef239d-ad61-463e-bbd8-b14c34362a88"},{"condition":"Timeout","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"NoMatch","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"silver","namespace":"External"},{"name":"TextToSpeechType","value":"ssml"},{"name":"Timeout","value":"1"},{"name":"MaxDigits","value":"1"}],"metadata":{"position":{"x":1872,"y":435},"conditionMetadata":[{"id":"9658bc54-ac52-4b91-934c-83322ec83cda","value":"9"}],"useDynamic":true},"target":"Digits"},{"id":"025df89c-5036-4627-b7a0-0ba3e999b8c2","type":"Loop","branches":[{"condition":"Looping","transition":"51aed40c-bdb7-4046-9022-df97d8f918a7"},{"condition":"Complete","transition":"b07e1f8f-a47b-4636-abe9-5d0933c28abd"}],"parameters":[{"name":"LoopCount","value":"10"}],"metadata":{"position":{"x":2362,"y":1279.5980580054606},"useDynamic":false}},{"id":"a4f6b0d8-e03d-43fc-b000-75e52e028b70","type":"Transfer","branches":[{"condition":"Success","transition":"b07e1f8f-a47b-4636-abe9-5d0933c28abd"},{"condition":"CallFailure","transition":"b07e1f8f-a47b-4636-abe9-5d0933c28abd"},{"condition":"Timeout","transition":"b07e1f8f-a47b-4636-abe9-5d0933c28abd"},{"condition":"Error","transition":"b07e1f8f-a47b-4636-abe9-5d0933c28abd"}],"parameters":[{"name":"TimeLimit","value":"30"},{"name":"BlindTransfer","value":false},{"name":"PhoneNumber","value":"+1617-222-3200"}],"metadata":{"position":{"x":405,"y":451},"CountryCode":"us"},"target":"PhoneNumber"},{"id":"378e525e-29ef-471b-b0a1-14b69e61f41e","type":"InvokeExternalResource","branches":[{"condition":"Success","transition":"88b8dfd5-2a0c-48b9-9004-781705cdd951"},{"condition":"Error","transition":"a7e9ad86-446d-4297-bee5-dad34db002a5"}],"parameters":[{"name":"FunctionArn","value":"arn:aws:lambda:us-east-1:434035161053:function:elevator-hotline-prod","namespace":null},{"name":"TimeLimit","value":"8"}],"metadata":{"position":{"x":65,"y":187.59805800546067},"dynamicMetadata":{},"useDynamic":false},"target":"Lambda"},{"id":"a7e9ad86-446d-4297-bee5-dad34db002a5","type":"PlayPrompt","branches":[{"condition":"Success","transition":"a4f6b0d8-e03d-43fc-b000-75e52e028b70"}],"parameters":[{"name":"Text","value":"Hello, you have reached the MBTA's elevator and escalator out-of-service update line. \n\nWe are currently experiencing some technical difficulties, and are now attempting to transfer you to a representative at number 617-222-3200","namespace":null},{"name":"TextToSpeechType","value":"text"}],"metadata":{"position":{"x":448,"y":256},"useDynamic":false}},{"id":"7a68c1c0-f93e-4322-afcb-a3ac4057f254","type":"SetAttributes","branches":[{"condition":"Success","transition":"a93e74a8-355c-4b7c-9e86-a69f889095ce"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Attribute","value":"Stored customer input","key":"line_choice","namespace":"System"}],"metadata":{"position":{"x":984,"y":49.59805800546067}}},{"id":"51aed40c-bdb7-4046-9022-df97d8f918a7","type":"StoreUserInput","branches":[{"condition":"Success","transition":"7a68c1c0-f93e-4322-afcb-a3ac4057f254"},{"condition":"Error","transition":"025df89c-5036-4627-b7a0-0ba3e999b8c2"}],"parameters":[{"name":"Text","value":"For outages affecting the red line, press one.\nFor outages affecting the orange line, press two.\nFor outages affecting the green line, press three.\nFor outages affecting the blue line, press four.\nFor outages affecting the silver line, press five.\nFor outages affecting the commuter rail, press six.\nPress 9 to repeat the previous alerts or 0 to return to the main menu at any time."},{"name":"TextToSpeechType","value":"text"},{"name":"CustomerInputType","value":"Custom"},{"name":"Timeout","value":"6"},{"name":"MaxDigits","value":1},{"name":"EncryptEntry","value":"false"},{"name":"DisableCancel","value":"false"}],"metadata":{"position":{"x":763,"y":972},"useDynamic":false,"useDynamicForEncryptionKeys":true,"useDynamicForTerminatorDigits":false,"countryCodePrefix":"+1"}},{"id":"88b8dfd5-2a0c-48b9-9004-781705cdd951","type":"CheckAttribute","branches":[{"condition":"Evaluate","conditionType":"Equals","conditionValue":"200","transition":"7ec8cd24-a8a2-44bf-a130-d0d9e33ee010"},{"condition":"NoMatch","transition":"a7e9ad86-446d-4297-bee5-dad34db002a5"}],"parameters":[{"name":"Attribute","value":"status"},{"name":"Namespace","value":"External"}],"metadata":{"position":{"x":420,"y":30.598058005460672},"conditionMetadata":[{"id":"44e1aebc-3e84-4320-b676-2d9502e520f2","operator":{"name":"Equals","value":"Equals","shortDisplay":"="},"value":"200"}]}},{"id":"7ec8cd24-a8a2-44bf-a130-d0d9e33ee010","type":"StoreUserInput","branches":[{"condition":"Success","transition":"7a68c1c0-f93e-4322-afcb-a3ac4057f254"},{"condition":"Error","transition":"51aed40c-bdb7-4046-9022-df97d8f918a7"}],"parameters":[{"name":"Text","value":"Hello, you have reached the MBTA's elevator and escalator out-of-service update line. This recording is updated in real time.\n\nFor outages affecting the red line, press one.\nFor outages affecting the orange line, press two.\nFor outages affecting the green line, press three.\nFor outages affecting the blue line, press four.\nFor outages affecting the silver line, press five.\nFor outages affecting the commuter rail, press six.\nPress 9 to repeat the previous alerts or 0 to return to the main menu at any time.","namespace":null},{"name":"TextToSpeechType","value":"text"},{"name":"CustomerInputType","value":"Custom"},{"name":"Timeout","value":"6"},{"name":"MaxDigits","value":1},{"name":"EncryptEntry","value":false},{"name":"DisableCancel","value":"false"}],"metadata":{"position":{"x":681,"y":28},"useDynamic":false,"useDynamicForEncryptionKeys":true,"useDynamicForTerminatorDigits":false,"countryCodePrefix":"+1"}}],"version":"1","type":"contactFlow","start":"6c745c27-6c4d-4eb1-87fa-6986c7e785b7","metadata":{"entryPointPosition":{"x":15.500339628716162,"y":18.09805800546067},"snapToGrid":false,"name":"MBTA Elevator Hotline","description":null,"type":"contactFlow","status":"published","hash":"f91a956117b0ef9ddb3f1726a1f95bf36f1f5e186c4e416bc1dbaa4cf2b2c077"}}
+{
+  "modules": [
+    {
+      "id": "6c745c27-6c4d-4eb1-87fa-6986c7e785b7",
+      "type": "SetLoggingBehavior",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "378e525e-29ef-471b-b0a1-14b69e61f41e"
+        }
+      ],
+      "parameters": [{ "name": "LoggingBehavior", "value": "Enable" }],
+      "metadata": { "position": { "x": 141, "y": 20.59805800546067 } }
+    },
+    {
+      "id": "52e502c3-221e-4fad-a4db-9892481f2116",
+      "type": "Disconnect",
+      "branches": [],
+      "parameters": [],
+      "metadata": { "position": { "x": 446, "y": 1012 } }
+    },
+    {
+      "id": "b07e1f8f-a47b-4636-abe9-5d0933c28abd",
+      "type": "PlayPrompt",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "52e502c3-221e-4fad-a4db-9892481f2116"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Text",
+          "value": "Thank you for calling. Goodbye.",
+          "namespace": null
+        },
+        { "name": "TextToSpeechType", "value": "text" }
+      ],
+      "metadata": { "position": { "x": 320, "y": 792 }, "useDynamic": false }
+    },
+    {
+      "id": "a93e74a8-355c-4b7c-9e86-a69f889095ce",
+      "type": "SetAttributes",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "864985be-4aa7-4c5f-ba40-638da53f09d0"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Attribute",
+          "value": "line_choice_log$.Attributes.line_choice",
+          "key": "line_choice_log",
+          "namespace": "User Defined"
+        }
+      ],
+      "metadata": { "position": { "x": 1261, "y": 70.59805800546067 } }
+    },
+    {
+      "id": "ff737200-4608-467e-95e6-6d2d5a3f116d",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "commuter", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 1870, "y": 717.5980580054606 },
+        "conditionMetadata": [
+          { "id": "379751ca-c0e6-4dbf-84b3-7f17ae05e359", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "b8839179-7ddc-4e4c-befc-f2b356445738",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "orange", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 2227, "y": 287 },
+        "conditionMetadata": [
+          { "id": "feddca92-66bb-46e2-a45e-5ebd6f80f6e8", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "33b1deb0-2bec-40b5-b5e3-502b292e94ba",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "green", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 2228, "y": 555 },
+        "conditionMetadata": [
+          { "id": "bd3be66e-7634-40ef-92bc-7b1b3ba8e4df", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "43bba9b9-fddb-4fb7-acb2-0575ac413964",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "blue", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 2222, "y": 834 },
+        "conditionMetadata": [
+          { "id": "2b5a9690-6267-446e-942f-70ae71c50d8e", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "26e30010-50fb-42df-a6b2-ea51b62c38a5",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "red", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 2223, "y": 15.5 },
+        "conditionMetadata": [
+          { "id": "e8eb793b-ca99-42ec-83ae-d3c73bae21c6", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "e3ef239d-ad61-463e-bbd8-b14c34362a88",
+      "type": "Loop",
+      "branches": [
+        {
+          "condition": "Looping",
+          "transition": "864985be-4aa7-4c5f-ba40-638da53f09d0"
+        },
+        {
+          "condition": "Complete",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [{ "name": "LoopCount", "value": "10" }],
+      "metadata": {
+        "position": { "x": 1307, "y": 695.8029243487802 },
+        "useDynamic": false
+      }
+    },
+    {
+      "id": "864985be-4aa7-4c5f-ba40-638da53f09d0",
+      "type": "CheckAttribute",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "1",
+          "transition": "26e30010-50fb-42df-a6b2-ea51b62c38a5"
+        },
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "2",
+          "transition": "b8839179-7ddc-4e4c-befc-f2b356445738"
+        },
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "3",
+          "transition": "33b1deb0-2bec-40b5-b5e3-502b292e94ba"
+        },
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "4",
+          "transition": "43bba9b9-fddb-4fb7-acb2-0575ac413964"
+        },
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "5",
+          "transition": "93ec5f16-a5cb-49f5-9f1d-fcff0642b856"
+        },
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "6",
+          "transition": "ff737200-4608-467e-95e6-6d2d5a3f116d"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Attribute", "value": "line_choice" },
+        { "name": "Namespace", "value": "User Defined" }
+      ],
+      "metadata": {
+        "position": { "x": 1567, "y": 21 },
+        "conditionMetadata": [
+          {
+            "id": "bfc45702-3ba3-4c93-8a58-0996654f2945",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "1"
+          },
+          {
+            "id": "56644aa9-04ba-4523-806e-b347385d1a6f",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "2"
+          },
+          {
+            "id": "5ed0bc7b-d7af-4f5c-815a-6bf7fe926c10",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "3"
+          },
+          {
+            "id": "aa505e28-96db-43a3-8b44-12070cecfe37",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "4"
+          },
+          {
+            "id": "30e8ce40-66ea-405f-8a9e-ed834249ddf2",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "5"
+          },
+          {
+            "id": "b5a5cd72-34fa-4c1a-80bf-09c1988702b0",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "6"
+          }
+        ]
+      }
+    },
+    {
+      "id": "93ec5f16-a5cb-49f5-9f1d-fcff0642b856",
+      "type": "GetUserInput",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "9",
+          "transition": "e3ef239d-ad61-463e-bbd8-b14c34362a88"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        { "name": "Text", "value": "silver", "namespace": "External" },
+        { "name": "TextToSpeechType", "value": "ssml" },
+        { "name": "Timeout", "value": "1" },
+        { "name": "MaxDigits", "value": "1" }
+      ],
+      "metadata": {
+        "position": { "x": 1872, "y": 435 },
+        "conditionMetadata": [
+          { "id": "9658bc54-ac52-4b91-934c-83322ec83cda", "value": "9" }
+        ],
+        "useDynamic": true
+      },
+      "target": "Digits"
+    },
+    {
+      "id": "025df89c-5036-4627-b7a0-0ba3e999b8c2",
+      "type": "Loop",
+      "branches": [
+        {
+          "condition": "Looping",
+          "transition": "51aed40c-bdb7-4046-9022-df97d8f918a7"
+        },
+        {
+          "condition": "Complete",
+          "transition": "b07e1f8f-a47b-4636-abe9-5d0933c28abd"
+        }
+      ],
+      "parameters": [{ "name": "LoopCount", "value": "10" }],
+      "metadata": {
+        "position": { "x": 2362, "y": 1279.5980580054606 },
+        "useDynamic": false
+      }
+    },
+    {
+      "id": "a4f6b0d8-e03d-43fc-b000-75e52e028b70",
+      "type": "Transfer",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "b07e1f8f-a47b-4636-abe9-5d0933c28abd"
+        },
+        {
+          "condition": "CallFailure",
+          "transition": "b07e1f8f-a47b-4636-abe9-5d0933c28abd"
+        },
+        {
+          "condition": "Timeout",
+          "transition": "b07e1f8f-a47b-4636-abe9-5d0933c28abd"
+        },
+        {
+          "condition": "Error",
+          "transition": "b07e1f8f-a47b-4636-abe9-5d0933c28abd"
+        }
+      ],
+      "parameters": [
+        { "name": "TimeLimit", "value": "30" },
+        { "name": "BlindTransfer", "value": false },
+        { "name": "PhoneNumber", "value": "+1617-222-3200" }
+      ],
+      "metadata": { "position": { "x": 405, "y": 451 }, "CountryCode": "us" },
+      "target": "PhoneNumber"
+    },
+    {
+      "id": "378e525e-29ef-471b-b0a1-14b69e61f41e",
+      "type": "InvokeExternalResource",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "88b8dfd5-2a0c-48b9-9004-781705cdd951"
+        },
+        {
+          "condition": "Error",
+          "transition": "a7e9ad86-446d-4297-bee5-dad34db002a5"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "FunctionArn",
+          "value": "arn:aws:lambda:us-east-1:434035161053:function:elevator-hotline-prod",
+          "namespace": null
+        },
+        { "name": "TimeLimit", "value": "8" }
+      ],
+      "metadata": {
+        "position": { "x": 65, "y": 187.59805800546067 },
+        "dynamicMetadata": {},
+        "useDynamic": false
+      },
+      "target": "Lambda"
+    },
+    {
+      "id": "a7e9ad86-446d-4297-bee5-dad34db002a5",
+      "type": "PlayPrompt",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "a4f6b0d8-e03d-43fc-b000-75e52e028b70"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Text",
+          "value": "Hello, you have reached the MBTA's elevator and escalator out-of-service update line. \n\nWe are currently experiencing some technical difficulties, and are now attempting to transfer you to a representative at number 617-222-3200",
+          "namespace": null
+        },
+        { "name": "TextToSpeechType", "value": "text" }
+      ],
+      "metadata": { "position": { "x": 448, "y": 256 }, "useDynamic": false }
+    },
+    {
+      "id": "7a68c1c0-f93e-4322-afcb-a3ac4057f254",
+      "type": "SetAttributes",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "a93e74a8-355c-4b7c-9e86-a69f889095ce"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Attribute",
+          "value": "Stored customer input",
+          "key": "line_choice",
+          "namespace": "System"
+        }
+      ],
+      "metadata": { "position": { "x": 984, "y": 49.59805800546067 } }
+    },
+    {
+      "id": "51aed40c-bdb7-4046-9022-df97d8f918a7",
+      "type": "StoreUserInput",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "7a68c1c0-f93e-4322-afcb-a3ac4057f254"
+        },
+        {
+          "condition": "Error",
+          "transition": "025df89c-5036-4627-b7a0-0ba3e999b8c2"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Text",
+          "value": "For outages affecting the red line, press one.\nFor outages affecting the orange line, press two.\nFor outages affecting the green line, press three.\nFor outages affecting the blue line, press four.\nFor outages affecting the silver line, press five.\nFor outages affecting the commuter rail, press six.\nPress 9 to repeat the previous alerts or 0 to return to the main menu at any time."
+        },
+        { "name": "TextToSpeechType", "value": "text" },
+        { "name": "CustomerInputType", "value": "Custom" },
+        { "name": "Timeout", "value": "6" },
+        { "name": "MaxDigits", "value": 1 },
+        { "name": "EncryptEntry", "value": "false" },
+        { "name": "DisableCancel", "value": "false" }
+      ],
+      "metadata": {
+        "position": { "x": 763, "y": 972 },
+        "useDynamic": false,
+        "useDynamicForEncryptionKeys": true,
+        "useDynamicForTerminatorDigits": false,
+        "countryCodePrefix": "+1"
+      }
+    },
+    {
+      "id": "88b8dfd5-2a0c-48b9-9004-781705cdd951",
+      "type": "CheckAttribute",
+      "branches": [
+        {
+          "condition": "Evaluate",
+          "conditionType": "Equals",
+          "conditionValue": "200",
+          "transition": "7ec8cd24-a8a2-44bf-a130-d0d9e33ee010"
+        },
+        {
+          "condition": "NoMatch",
+          "transition": "a7e9ad86-446d-4297-bee5-dad34db002a5"
+        }
+      ],
+      "parameters": [
+        { "name": "Attribute", "value": "status" },
+        { "name": "Namespace", "value": "External" }
+      ],
+      "metadata": {
+        "position": { "x": 420, "y": 30.598058005460672 },
+        "conditionMetadata": [
+          {
+            "id": "44e1aebc-3e84-4320-b676-2d9502e520f2",
+            "operator": {
+              "name": "Equals",
+              "value": "Equals",
+              "shortDisplay": "="
+            },
+            "value": "200"
+          }
+        ]
+      }
+    },
+    {
+      "id": "7ec8cd24-a8a2-44bf-a130-d0d9e33ee010",
+      "type": "StoreUserInput",
+      "branches": [
+        {
+          "condition": "Success",
+          "transition": "7a68c1c0-f93e-4322-afcb-a3ac4057f254"
+        },
+        {
+          "condition": "Error",
+          "transition": "51aed40c-bdb7-4046-9022-df97d8f918a7"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Text",
+          "value": "Hello, you have reached the MBTA's elevator and escalator out-of-service update line. This recording is updated in real time.\n\nFor outages affecting the red line, press one.\nFor outages affecting the orange line, press two.\nFor outages affecting the green line, press three.\nFor outages affecting the blue line, press four.\nFor outages affecting the silver line, press five.\nFor outages affecting the commuter rail, press six.\nPress 9 to repeat the previous alerts or 0 to return to the main menu at any time.",
+          "namespace": null
+        },
+        { "name": "TextToSpeechType", "value": "text" },
+        { "name": "CustomerInputType", "value": "Custom" },
+        { "name": "Timeout", "value": "6" },
+        { "name": "MaxDigits", "value": 1 },
+        { "name": "EncryptEntry", "value": false },
+        { "name": "DisableCancel", "value": "false" }
+      ],
+      "metadata": {
+        "position": { "x": 681, "y": 28 },
+        "useDynamic": false,
+        "useDynamicForEncryptionKeys": true,
+        "useDynamicForTerminatorDigits": false,
+        "countryCodePrefix": "+1"
+      }
+    }
+  ],
+  "version": "1",
+  "type": "contactFlow",
+  "start": "6c745c27-6c4d-4eb1-87fa-6986c7e785b7",
+  "metadata": {
+    "entryPointPosition": { "x": 15.500339628716162, "y": 18.09805800546067 },
+    "snapToGrid": false,
+    "name": "MBTA Elevator Hotline",
+    "description": null,
+    "type": "contactFlow",
+    "status": "published",
+    "hash": "f91a956117b0ef9ddb3f1726a1f95bf36f1f5e186c4e416bc1dbaa4cf2b2c077"
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,5 @@ const tsJestTransformCfg = createDefaultPreset().transform;
 /** @type {import("jest").Config} **/
 module.exports = {
   testEnvironment: "node",
-  transform: tsJestTransformCfg
+  transform: tsJestTransformCfg,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "dotenv": "^8.2.0",
         "esbuild": "^0.25.10",
         "jest": "^30.2.0",
-        "prettier": "2.0.5",
+        "prettier": "^3.6.2",
         "ts-jest": "^29.4.4",
         "tsx": "^4.20.6",
         "typescript": "^5.9.2"
@@ -4477,15 +4477,19 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "license": "MIT",
   "scripts": {
     "local": "tsx test/local.ts",
-    "prettier": "prettier --write src test",
-    "prettier:check": "prettier --check src test",
+    "format": "prettier --list-different --write .",
     "test": "jest"
   },
   "dependencies": {
@@ -19,7 +18,7 @@
     "dotenv": "^8.2.0",
     "esbuild": "^0.25.10",
     "jest": "^30.2.0",
-    "prettier": "2.0.5",
+    "prettier": "^3.6.2",
     "ts-jest": "^29.4.4",
     "tsx": "^4.20.6",
     "typescript": "^5.9.2"

--- a/src/alerts.ts
+++ b/src/alerts.ts
@@ -51,6 +51,7 @@ export const get = (apiKey: string): Promise<Response> => {
 
   return client.get(url).then((response) => {
     let alert_entities: Record<string, null> = {};
+
     const alerts = response.data
       .filter((alert) => {
         return (
@@ -82,11 +83,13 @@ export const get = (apiKey: string): Promise<Response> => {
           updatedAt: new Date(attributes.updated_at).getTime(),
         };
       });
+
     if (alerts.length == 0) {
       console.log(
         "Error: alerts returned no alerts when called, probably a problem."
       );
     }
+
     return {
       alerts: alerts,
       entities: Object.keys(alert_entities),

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ function initHandler(lambdaHandler: typeof lambda) {
     const fs = require("fs");
 
     dotenv.config();
+
     if (fs.existsSync(".env.override")) {
       const envConfig = dotenv.parse(fs.readFileSync(".env.override"));
       for (const k in envConfig) {
@@ -38,6 +39,7 @@ function initHandler(lambdaHandler: typeof lambda) {
       Sentry.captureException(error);
       await Sentry.flush(2000);
     }
+
     context.succeed({ status: "500" });
     return { status: "500" };
   };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -9,8 +9,10 @@ export const get = (apiKey: string, stop: string): Promise<Response> => {
   url.searchParams.append("filter[stop]", stop);
   url.searchParams.append("include", "stop");
   url.searchParams.append("api_key", apiKey);
+
   return client.get(url).then((response) => {
     let station = null;
+
     if (response.included && response.included.length != 0) {
       station = response.included.map(
         (included) => included.attributes.name as string
@@ -18,6 +20,7 @@ export const get = (apiKey: string, stop: string): Promise<Response> => {
     }
 
     const allRoutes = response.data.map((route) => route.id);
+
     return { stop: stop, name: station, routes: allRoutes };
   });
 };

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -5,6 +5,7 @@ export const get = (secretName: string): Promise<string> => {
     AWS.config.update({ region: process.env.AWS_REGION });
 
     const client = new AWS.SecretsManager({});
+
     client.getSecretValue({ SecretId: secretName }, (err, data) => {
       if (err) {
         if (err.code === "ResourceNotFoundException") {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,16 +14,14 @@ const pifyHandler = (fn: Handler) => {
 };
 
 const no_outages = {
-  blue:
-    "<speak> Currently there are no outages reported for the  blue line </speak>",
+  blue: "<speak> Currently there are no outages reported for the  blue line </speak>",
   commuter:
     "<speak> Currently there are no outages reported for the  commuter rail </speak>",
   green:
     "<speak> Currently there are no outages reported for the  green line </speak>",
   orange:
     "<speak> Currently there are no outages reported for the  orange line </speak>",
-  red:
-    "<speak> Currently there are no outages reported for the  red line </speak>",
+  red: "<speak> Currently there are no outages reported for the  red line </speak>",
   silver:
     "<speak> Currently there are no outages reported for the  silver line </speak>",
   status: "200",
@@ -55,8 +53,8 @@ test("if http client gets no alerts responds all lines okay.", () => {
     } else return Promise.reject();
   });
   console.log = jest.fn();
-  const fn = pifyHandler(handler);
 
+  const fn = pifyHandler(handler);
   return fn({}).then((result) => {
     expect(console.log).toHaveBeenCalledWith(
       "Error: alerts returned no alerts when called, probably a problem."
@@ -108,6 +106,7 @@ test("render one alert across multiple lines", () => {
     } else return Promise.reject();
   });
   console.log = jest.fn();
+
   const fn = pifyHandler(handler);
   return fn({}).then((result) => {
     expect(result).toStrictEqual({
@@ -165,6 +164,7 @@ test("only show alerts for elevator or escalator closure", () => {
       }
     } else return Promise.reject();
   });
+
   const fn = pifyHandler(handler);
   return fn({}).then((result) => {
     expect(result).toStrictEqual(no_outages);
@@ -185,6 +185,7 @@ test("warn on unmatched alert, but still return correctly", () => {
     } else return Promise.reject();
   });
   console.log = jest.fn();
+
   const fn = pifyHandler(handler);
   return fn({}).then((result) => {
     expect(console.log).toHaveBeenCalledWith(
@@ -223,8 +224,7 @@ test("render multiple alerts across multiple lines to test sorting", () => {
         '<speak><emphasis level="moderate"> North Station </emphasis> new elevator closure <break time="1s"/> Example header1. . example description new <break time="1s"/><emphasis level="moderate"> North Station </emphasis> ongoing elevator closure <break time="1s"/> Example header4. . example description <break time="1s"/> </speak>',
       orange:
         '<speak><emphasis level="moderate"> North Station </emphasis> new elevator closure <break time="1s"/> Example header1. . example description new <break time="1s"/><emphasis level="moderate"> North Station </emphasis> ongoing elevator closure <break time="1s"/> Example header4. . example description <break time="1s"/> </speak>',
-      red:
-        '<speak><emphasis level="moderate"> Quincy Adams </emphasis> ongoing elevator closure <break time="1s"/> Example header6. . example description <break time="1s"/><emphasis level="moderate"> Quincy Adams </emphasis> ongoing elevator closure <break time="1s"/> Example header5. . example description5 <break time="1s"/><emphasis level="moderate"> Quincy Center </emphasis> ongoing_upcoming escalator closure <break time="1s"/> Example header2. . example description2 <break time="1s"/><emphasis level="moderate"> Quincy Center </emphasis> ongoing_upcoming access issue <break time="1s"/> Example header3. . example description3 <break time="1s"/> </speak>',
+      red: '<speak><emphasis level="moderate"> Quincy Adams </emphasis> ongoing elevator closure <break time="1s"/> Example header6. . example description <break time="1s"/><emphasis level="moderate"> Quincy Adams </emphasis> ongoing elevator closure <break time="1s"/> Example header5. . example description5 <break time="1s"/><emphasis level="moderate"> Quincy Center </emphasis> ongoing_upcoming escalator closure <break time="1s"/> Example header2. . example description2 <break time="1s"/><emphasis level="moderate"> Quincy Center </emphasis> ongoing_upcoming access issue <break time="1s"/> Example header3. . example description3 <break time="1s"/> </speak>',
       silver: no_outages.silver,
       status: no_outages.status,
     });


### PR DESCRIPTION
* Instead of only formatting specific files, format anything Prettier knows how to format that isn't gitignored. This primarily results in some minor changes to Markdown documents.

* Use `trailingComma: "es5"` as this seems to line up better with the existing code style.

* Add some blank lines to code files for readability.