### PR TITLE
fix: Dependabot not updating composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directories:
+      - "/.github/actions/*"
+      - "/.github/workflows"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Copied from: https://github.com/mbta/screens/commit/0b7a325c9a32ec409152f3b10ab067ae4b3ceac6

Using `/` as the directory of a `github-actions` ecosystem is actually an "alias" for `.github/workflows`, and so ignores our composite actions which live in subdirectories of `.github/actions`.

By switching to the `directories` field, we can specify multiple directories and they can include wildcards. Use this to include `actions/*` and also make the `workflows` "alias" explicit.