### PR TITLE
refactor: Consolidate route API calls into alerts fetch

### DIFF
--- a/src/alerts.ts
+++ b/src/alerts.ts
@@ -1,4 +1,100 @@
 import * as client from "./api_client";
+import { routesToLine, Line } from "./routes";
+
+type APIAlertAttributes = {
+  description: string | null;
+  effect: string;
+  header: string;
+  informed_entity: { stop: string; route: string | null }[];
+  lifecycle: string;
+  updated_at: string;
+};
+
+type StopId = string;
+
+type StopToName = Record<StopId, string>;
+
+type Entity = {
+  stop_name: string;
+  line: Line;
+};
+
+export type Alert = {
+  id: string;
+  type: string;
+  lifecycle: string;
+  description: string;
+  entities: Entity[];
+  updatedAt: number;
+};
+
+const validAlertEffects = [
+  "ELEVATOR_CLOSURE",
+  "ESCALATOR_CLOSURE",
+  "ACCESS_ISSUE",
+];
+
+export const get = (apiKey: string): Promise<Alert[]> => {
+  const url = new URL("/alerts", client.base());
+  url.searchParams.append(
+    "fields[alert]",
+    "updated_at,effect,description,header,informed_entity,lifecycle"
+  );
+  url.searchParams.append("fields[route]", "id");
+  url.searchParams.append("include", "stops");
+  url.searchParams.append("api_key", apiKey);
+
+  return client.get(url).then((response) => {
+    // Map parent station IDs to stop name to use when rendering alerts
+    const stopsToName = response.included
+      ? response
+          .included!.filter((included) => included.type == "stop")
+          .reduce((acc, stop) => {
+            if (stop.attributes.location_type === 1 && stop.attributes.name) {
+              acc[stop.id] = stop.attributes.name as string;
+            }
+            return acc;
+          }, {} as StopToName)
+      : {};
+
+    return response.data
+      .filter((alert) => {
+        const attributes = alert.attributes as APIAlertAttributes;
+        return validAlertEffects.includes(attributes.effect);
+      })
+      .map((alert) => {
+        const attributes = alert.attributes as APIAlertAttributes;
+        const description = [
+          cleanUpText(attributes.header),
+          ".",
+          cleanUpText(attributes.description ?? ""),
+          '<break time="1s"/>',
+        ].join(" ");
+
+        // Find each unique Stop and Line affected by the alert,
+        // and filter down to only include those Entities
+        const entityMap = new Map<string, Entity>();
+        attributes.informed_entity.forEach((entity) => {
+          const stopName = stopsToName[entity.stop];
+          const line = routesToLine[entity.route!];
+          const key = `${stopName}-${line}`;
+          if (stopName && line && !entityMap.has(key)) {
+            entityMap.set(key, { stop_name: stopName!, line: line });
+          }
+        });
+
+        return {
+          id: alert.id,
+          type: attributes.effect.toLowerCase().replace("_", " "),
+          lifecycle: attributes.lifecycle,
+          description: description,
+          entities: Array.from(entityMap.values()),
+          updatedAt: new Date(attributes.updated_at).getTime(),
+        };
+      })
+      .filter((alert) => alert.entities.length > 0);
+  });
+};
 
 function cleanUpText(input: string) {
   return input
@@ -14,134 +110,3 @@ function cleanUpText(input: string) {
     .replace(/\r\n\r\n/g, ' <break time="1s"/> ')
     .replace(/\r\n/g, ' <break time="1s"/> ');
 }
-
-type RouteType = number | null;
-
-type APIAlertAttributes = {
-  description: string | null;
-  effect: string;
-  header: string;
-  informed_entity: { stop: string | null; route_type: RouteType, route: string | null}[];
-  lifecycle: string;
-  updated_at: string;
-};
-
-type StopId = string;
-
-export type Alert = {
-  id: string;
-  type: string;
-  lifecycle: string;
-  description: string;
-  entities: Entity[];
-  updatedAt: number;
-};
-
-type Entity = {
-  stop_name: string;
-  route: Line;
-}
-
-type Response = {
-  alerts: Alert[];
-};
-
-
-type RouteId = string;
-type Line = "red" | "orange" | "green" | "blue" | "silver" | "commuter";
-
-function config(item: string) {
-  return process.env[item]!;
-}
-
-function getLine(line: string, line_id: Line) {
-  return config(line)
-    .split(",")
-    .map((item) => {
-      return { line: item.trim(), id: line_id };
-    });
-}  const route_ids = [
-    getLine("LINE_RED", "red"),
-    getLine("LINE_ORANGE", "orange"),
-    getLine("LINE_GREEN", "green"),
-    getLine("LINE_BLUE", "blue"),
-    getLine("LINE_SILVER", "silver"),
-    getLine("LINE_COMMUTER", "commuter"),
-  ].reduce((acc, val) => [...acc, ...val], []);
-
-
-  const routes_table = route_ids.reduce(
-    (acc, route) => {
-      acc[route.line] = route.id;
-      return acc;
-    },
-    {} as Record<RouteId, Line>
-  );
-
-
-export const get = (apiKey: string): Promise<Response> => {
-  const url = new URL("/alerts", client.base());
-  url.searchParams.append(
-    "fields[alert]",
-    "updated_at,effect,description,header,informed_entity,lifecycle"
-  );
-  url.searchParams.append("fields[route]", "id");
-  url.searchParams.append("include", "stops");
-  url.searchParams.append("api_key", apiKey);
-
-  return client.get(url).then((response) => {
-    const stops = response.included!.filter((included) => included.type == "stop").reduce(
-    (acc, stop) => {
-      if ((stop.attributes.location_type === 1) && stop.attributes.name) {
-        acc[stop.id] = stop.attributes.name as string | null;
-      }
-      return acc;
-    },
-    {} as Record<StopId, string | null>
-  );
-    const alerts = response.data
-      .filter((alert) => {
-        return (
-          alert.attributes.effect === "ELEVATOR_CLOSURE" ||
-          alert.attributes.effect === "ESCALATOR_CLOSURE" ||
-          alert.attributes.effect === "ACCESS_ISSUE"
-        );
-      })
-      .map((alert) => {
-        const attributes = alert.attributes as APIAlertAttributes;
-        const description = [
-          cleanUpText(attributes.header),
-          ".",
-          cleanUpText(attributes.description ?? ""),
-          '<break time="1s"/>',
-        ].join(" ");
-
-        const entityMap = new Map<string, Entity>();
-        attributes.informed_entity
-          .forEach((entity) => {
-            const stopName = stops[entity.stop!];
-            const line = routes_table[entity.route!];
-            const key = `${stopName}-${line!}`;
-            if (stopName && line && !entityMap.has(key)) {
-              console.log( { stop_name: stopName!, route: entity.route!, stop_id: entity.stop!, route_type: entity.route_type! });
-              entityMap.set(key, { stop_name: stopName!, route: line });
-            }
-          });
-        const alert_entities = Array.from(entityMap.values());
-
-        console.log(entityMap);
-        return {
-          id: alert.id,
-          type: attributes.effect.toLowerCase().replace("_", " "),
-          lifecycle: attributes.lifecycle,
-          description: description,
-          entities: alert_entities,
-          updatedAt: new Date(attributes.updated_at).getTime(),
-        };
-      })
-      .filter((alert) => alert.entities.length > 0);
-    return {
-      alerts: alerts,
-    };
-  });
-};

--- a/src/alerts.ts
+++ b/src/alerts.ts
@@ -47,14 +47,17 @@ export const get = (apiKey: string): Promise<Alert[]> => {
   return client.get(url).then((response) => {
     // Map parent station IDs to stop name to use when rendering alerts
     const stopsToName = response.included
-      ? response
-          .included!.filter((included) => included.type == "stop")
-          .reduce((acc, stop) => {
-            if (stop.attributes.location_type === 1 && stop.attributes.name) {
-              acc[stop.id] = stop.attributes.name as string;
+      ? response.included
+          .filter((included) => included.type == "stop")
+          .reduce((acc: StopToName, stop) => {
+            if (
+              stop.attributes.location_type === 1 &&
+              typeof stop.attributes.name === "string"
+            ) {
+              acc[stop.id] = stop.attributes.name;
             }
             return acc;
-          }, {} as StopToName)
+          }, {})
       : {};
 
     return response.data
@@ -79,7 +82,7 @@ export const get = (apiKey: string): Promise<Alert[]> => {
           const line = routesToLine[entity.route!];
           const key = `${stopName}-${line}`;
           if (stopName && line && !entityMap.has(key)) {
-            entityMap.set(key, { stop_name: stopName!, line: line });
+            entityMap.set(key, { stop_name: stopName, line: line });
           }
         });
 

--- a/src/alerts.ts
+++ b/src/alerts.ts
@@ -21,7 +21,7 @@ type APIAlertAttributes = {
   description: string | null;
   effect: string;
   header: string;
-  informed_entity: { stop: string | null; route_type: RouteType }[];
+  informed_entity: { stop: string | null; route_type: RouteType, route: string | null}[];
   lifecycle: string;
   updated_at: string;
 };
@@ -33,17 +33,51 @@ export type Alert = {
   type: string;
   lifecycle: string;
   description: string;
-  entities: StopId[];
+  entities: Entity[];
   updatedAt: number;
 };
 
+type Entity = {
+  stop_name: string;
+  route: Line;
+}
+
 type Response = {
   alerts: Alert[];
-  entities: StopId[];
 };
 
-// Only capture alerts for CR, subway, or light rail
-const validRouteTypes: RouteType[] = [0, 1, 2];
+
+type RouteId = string;
+type Line = "red" | "orange" | "green" | "blue" | "silver" | "commuter";
+
+function config(item: string) {
+  return process.env[item]!;
+}
+
+function getLine(line: string, line_id: Line) {
+  return config(line)
+    .split(",")
+    .map((item) => {
+      return { line: item.trim(), id: line_id };
+    });
+}  const route_ids = [
+    getLine("LINE_RED", "red"),
+    getLine("LINE_ORANGE", "orange"),
+    getLine("LINE_GREEN", "green"),
+    getLine("LINE_BLUE", "blue"),
+    getLine("LINE_SILVER", "silver"),
+    getLine("LINE_COMMUTER", "commuter"),
+  ].reduce((acc, val) => [...acc, ...val], []);
+
+
+  const routes_table = route_ids.reduce(
+    (acc, route) => {
+      acc[route.line] = route.id;
+      return acc;
+    },
+    {} as Record<RouteId, Line>
+  );
+
 
 export const get = (apiKey: string): Promise<Response> => {
   const url = new URL("/alerts", client.base());
@@ -51,12 +85,20 @@ export const get = (apiKey: string): Promise<Response> => {
     "fields[alert]",
     "updated_at,effect,description,header,informed_entity,lifecycle"
   );
-  url.searchParams.append("fields[activity]", "ALL");
+  url.searchParams.append("fields[route]", "id");
+  url.searchParams.append("include", "stops");
   url.searchParams.append("api_key", apiKey);
 
   return client.get(url).then((response) => {
-    const alert_entities: Record<string, null> = {};
-
+    const stops = response.included!.filter((included) => included.type == "stop").reduce(
+    (acc, stop) => {
+      if ((stop.attributes.location_type === 1) && stop.attributes.name) {
+        acc[stop.id] = stop.attributes.name as string | null;
+      }
+      return acc;
+    },
+    {} as Record<StopId, string | null>
+  );
     const alerts = response.data
       .filter((alert) => {
         return (
@@ -74,31 +116,32 @@ export const get = (apiKey: string): Promise<Response> => {
           '<break time="1s"/>',
         ].join(" ");
 
-        const entities = Array.from(
-          new Set(
-            attributes.informed_entity
-              .filter((entity) => validRouteTypes.includes(entity.route_type))
-              .map((entity) => {
-                alert_entities[entity.stop!] = null;
-                return entity.stop!;
-              })
-          )
-        );
+        const entityMap = new Map<string, Entity>();
+        attributes.informed_entity
+          .forEach((entity) => {
+            const stopName = stops[entity.stop!];
+            const line = routes_table[entity.route!];
+            const key = `${stopName}-${line!}`;
+            if (stopName && line && !entityMap.has(key)) {
+              console.log( { stop_name: stopName!, route: entity.route!, stop_id: entity.stop!, route_type: entity.route_type! });
+              entityMap.set(key, { stop_name: stopName!, route: line });
+            }
+          });
+        const alert_entities = Array.from(entityMap.values());
 
+        console.log(entityMap);
         return {
           id: alert.id,
           type: attributes.effect.toLowerCase().replace("_", " "),
           lifecycle: attributes.lifecycle,
           description: description,
-          entities: entities,
+          entities: alert_entities,
           updatedAt: new Date(attributes.updated_at).getTime(),
         };
       })
       .filter((alert) => alert.entities.length > 0);
-
     return {
       alerts: alerts,
-      entities: Object.keys(alert_entities),
     };
   });
 };

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,14 +1,11 @@
 import * as Sentry from "@sentry/node";
-import * as alerts from "./alerts";
-import * as routes from "./routes";
+import { Alert, get as getAlerts } from "./alerts";
 
 type Line = "red" | "orange" | "green" | "blue" | "silver" | "commuter";
 type RouteId = string;
-type StopId = string;
 
-type AlertWithExtras = alerts.Alert & {
-  name?: string | null;
-  station?: string;
+type AlertWithStopName = Alert & {
+  stop_name?: string | null;
 };
 
 function config(item: string) {
@@ -42,7 +39,7 @@ function type_order(type: string) {
   return 0;
 }
 
-function compare_types(a: AlertWithExtras, b: AlertWithExtras) {
+function compare_types(a: Alert, b: Alert) {
   if (type_order(a.type) > type_order(b.type)) {
     return -1;
   } else if (type_order(a.type) < type_order(b.type)) {
@@ -82,54 +79,15 @@ const lambda = async function () {
     {} as Record<RouteId, Line>
   );
 
-  const alertsResponse = await alerts.get(config("API_KEY"));
-
-  const routesResponses = await Promise.all(
-    alertsResponse.entities.map((entity) =>
-      routes.get(config("API_KEY"), entity)
-    )
-  );
-
-  const stops = routesResponses.reduce(
-    (acc, response) => {
-      acc[response.stop] = {
-        name: response.name,
-        routes: Object.keys(
-          response.routes.reduce(
-            (acc, route) => {
-              acc[routes_table[route]] = true;
-              return acc;
-            },
-            {} as Record<Line, true>
-          )
-        ) as Line[],
-      };
-      return acc;
-    },
-    {} as Record<StopId, { name: string | null; routes: Line[] }>
-  );
+  const alertsResponse = await getAlerts(config("API_KEY"));
 
   const lines = alertsResponse.alerts.reduce(
-    (acc, alert: AlertWithExtras) => {
-      alert.station = alert.entities.find((entity) => {
-        if (stops[entity].routes.length != 0) {
-          return stops[entity].routes.some((route) => route in acc);
-        }
-        return false;
-      });
+    (acc, alert: AlertWithStopName) => {        
+      alert.entities.map((entity) => {
+          alert.stop_name = entity.stop_name;
+            acc[entity.route].push(alert);
 
-      if (alert.station && stops[alert.station]) {
-        alert.name = stops[alert.station].name;
-        stops[alert.station].routes.map((route) => {
-          if (route in acc) {
-            acc[route].push(alert);
-          }
-        });
-      } else {
-        const message = "Alert for a station not in routes";
-        console.log(`Error: ${message} ${JSON.stringify(alert)}`);
-        Sentry.captureMessage(message, { extra: alert, level: "error" });
-      }
+    })
 
       return acc;
     },
@@ -140,7 +98,7 @@ const lambda = async function () {
       blue: [],
       silver: [],
       commuter: [],
-    } as Record<Line, AlertWithExtras[]>
+    } as Record<Line, AlertWithStopName[]>
   );
 
   const output = {
@@ -163,7 +121,7 @@ const lambda = async function () {
         (output[line] = [
           output[line],
           '<emphasis level="moderate"> ',
-          alert.name,
+          alert.stop_name,
           " </emphasis> ",
           alert.lifecycle.toLowerCase(),
           " ",

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,7 +1,5 @@
 import { Alert, get as getAlerts } from "./alerts";
-
-type Line = "red" | "orange" | "green" | "blue" | "silver" | "commuter";
-type RouteId = string;
+import { Line } from "./routes";
 
 type AlertWithStopName = Alert & {
   stop_name?: string | null;

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/node";
 import { Alert, get as getAlerts } from "./alerts";
 
 type Line = "red" | "orange" | "green" | "blue" | "silver" | "commuter";
@@ -10,14 +9,6 @@ type AlertWithStopName = Alert & {
 
 function config(item: string) {
   return process.env[item]!;
-}
-
-function getLine(line: string, line_id: Line) {
-  return config(line)
-    .split(",")
-    .map((item) => {
-      return { line: item.trim(), id: line_id };
-    });
 }
 
 function defaultMessage(line: string) {
@@ -62,32 +53,17 @@ function compare_types(a: Alert, b: Alert) {
 }
 
 const lambda = async function () {
-  const route_ids = [
-    getLine("LINE_RED", "red"),
-    getLine("LINE_ORANGE", "orange"),
-    getLine("LINE_GREEN", "green"),
-    getLine("LINE_BLUE", "blue"),
-    getLine("LINE_SILVER", "silver"),
-    getLine("LINE_COMMUTER", "commuter"),
-  ].reduce((acc, val) => [...acc, ...val], []);
-
-  const routes_table = route_ids.reduce(
-    (acc, route) => {
-      acc[route.line] = route.id;
-      return acc;
-    },
-    {} as Record<RouteId, Line>
-  );
-
   const alertsResponse = await getAlerts(config("API_KEY"));
 
-  const lines = alertsResponse.alerts.reduce(
-    (acc, alert: AlertWithStopName) => {        
-      alert.entities.map((entity) => {
-          alert.stop_name = entity.stop_name;
-            acc[entity.route].push(alert);
-
-    })
+  const alertsByLine = alertsResponse.reduce(
+    (acc, alert: Alert) => {
+      alert.entities.forEach((entity) => {
+        const alertWithStop: AlertWithStopName = {
+          ...alert,
+          stop_name: entity.stop_name,
+        };
+        acc[entity.line].push(alertWithStop);
+      });
 
       return acc;
     },
@@ -111,12 +87,12 @@ const lambda = async function () {
     commuter: defaultMessage("commuter rail"),
   };
 
-  (Object.keys(lines) as Line[]).forEach((line) => {
-    lines[line].sort((a, b) => compare_types(a, b));
+  (Object.keys(alertsByLine) as Line[]).forEach((line) => {
+    alertsByLine[line].sort((a, b) => compare_types(a, b));
 
-    if (lines[line].length != 0) output[line] = "<speak>";
+    if (alertsByLine[line].length !== 0) output[line] = "<speak>";
 
-    lines[line].map(
+    alertsByLine[line].map(
       (alert) =>
         (output[line] = [
           output[line],
@@ -131,7 +107,8 @@ const lambda = async function () {
         ].join(""))
     );
 
-    if (lines[line].length != 0) output[line] = output[line] + " </speak>";
+    if (alertsByLine[line].length !== 0)
+      output[line] = output[line] + " </speak>";
   });
 
   return output;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -22,7 +22,7 @@ const routeIds = [
 ].reduce((acc, val) => [...acc, ...val], []);
 
 export const routesToLine = routeIds.reduce(
-  (acc, route) => {
+  (acc: Record<RouteId, Line>, route) => {
     acc[route.line] = route.id;
     return acc;
   },

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,26 +1,30 @@
-import * as client from "./api_client";
+export type Line = "red" | "orange" | "green" | "blue" | "silver" | "commuter";
+type RouteId = string;
 
-type Response = { stop: string; name: string | null; routes: string[] };
+function config(item: string) {
+  return process.env[item]!;
+}
 
-export const get = (apiKey: string, stop: string): Promise<Response> => {
-  const url = new URL("/routes", client.base());
-  url.searchParams.append("fields[route]", "id");
-  url.searchParams.append("fields[stop]", "name");
-  url.searchParams.append("filter[stop]", stop);
-  url.searchParams.append("include", "stop");
-  url.searchParams.append("api_key", apiKey);
+function getLine(line: string, line_id: Line) {
+  return config(line)
+    .split(",")
+    .map((item) => {
+      return { line: item.trim(), id: line_id };
+    });
+}
+const routeIds = [
+  getLine("LINE_RED", "red"),
+  getLine("LINE_ORANGE", "orange"),
+  getLine("LINE_GREEN", "green"),
+  getLine("LINE_BLUE", "blue"),
+  getLine("LINE_SILVER", "silver"),
+  getLine("LINE_COMMUTER", "commuter"),
+].reduce((acc, val) => [...acc, ...val], []);
 
-  return client.get(url).then((response) => {
-    let station = null;
-
-    if (response.included && response.included.length != 0) {
-      station = response.included.map(
-        (included) => included.attributes.name as string
-      )[0];
-    }
-
-    const allRoutes = response.data.map((route) => route.id);
-
-    return { stop: stop, name: station, routes: allRoutes };
-  });
-};
+export const routesToLine = routeIds.reduce(
+  (acc, route) => {
+    acc[route.line] = route.id;
+    return acc;
+  },
+  {} as Record<RouteId, Line>
+);

--- a/test/data.ts
+++ b/test/data.ts
@@ -1,6 +1,7 @@
 export const no_alerts = function () {
   return {
     data: [],
+    included: [],
     jsonapi: {
       version: "1.0",
     },
@@ -28,14 +29,8 @@ export const one_alert = function () {
             {
               activities: ["USING_WHEELCHAIR"],
               facility: "850",
-              stop: "70104",
-              route_type: 1,
-            },
-            {
-              activities: ["USING_WHEELCHAIR"],
-              facility: "850",
-              stop: "place-north",
-              route_type: 1,
+              stop: "place-qamnl",
+              route: "Red",
             },
           ],
           lifecycle: "ONGOING",
@@ -51,6 +46,78 @@ export const one_alert = function () {
           self: "/alerts/338973",
         },
         type: "alert",
+      },
+    ],
+    included: [
+      {
+        attributes: {
+          name: "Quincy Adams",
+          location_type: 1,
+        },
+        id: "place-qamnl",
+        type: "stop",
+      },
+    ],
+    jsonapi: {
+      version: "1.0",
+    },
+  };
+};
+
+export const one_alert_multiple_lines = function () {
+  return {
+    data: [
+      {
+        attributes: {
+          active_period: [
+            {
+              end: null,
+              start: "2019-11-12T04:30:00-05:00",
+            },
+          ],
+          banner: null,
+          cause: "UNKNOWN_CAUSE",
+          created_at: "2019-10-21T16:59:16-04:00",
+          description: "example description",
+          effect: "ELEVATOR_CLOSURE",
+          header: "Example header.",
+          informed_entity: [
+            {
+              activities: ["USING_WHEELCHAIR"],
+              facility: "850",
+              stop: "place-north",
+              route: "Orange",
+            },
+            {
+              activities: ["USING_WHEELCHAIR"],
+              facility: "850",
+              stop: "place-north",
+              route: "Green-C",
+            },
+          ],
+          lifecycle: "ONGOING",
+          service_effect: "elevator unavailable",
+          severity: 1,
+          short_header: "short header.",
+          timeframe: "ongoing",
+          updated_at: "2019-11-29T09:59:07-05:00",
+          url: null,
+        },
+        id: "338973",
+        links: {
+          self: "/alerts/338973",
+        },
+        type: "alert",
+      },
+    ],
+    included: [
+      {
+        attributes: {
+          name: "North Station",
+          location_type: 1,
+        },
+        id: "place-north",
+        type: "stop",
       },
     ],
     jsonapi: {
@@ -81,7 +148,7 @@ export const not_alert = function () {
               activities: ["USING_WHEELCHAIR"],
               facility: "850",
               stop: "place-north",
-              route_type: 0,
+              route: "Orange",
             },
           ],
           lifecycle: "ONGOING",
@@ -97,6 +164,16 @@ export const not_alert = function () {
           self: "/alerts/338973",
         },
         type: "alert",
+      },
+    ],
+    included: [
+      {
+        attributes: {
+          name: "North Station",
+          location_type: 1,
+        },
+        id: "place-north",
+        type: "stop",
       },
     ],
     jsonapi: {
@@ -127,7 +204,7 @@ export const unmatched_alert = function () {
               activities: ["USING_WHEELCHAIR"],
               facility: "852",
               stop: "place-south",
-              route_type: 0,
+              route: null,
             },
           ],
           lifecycle: "ONGOING",
@@ -143,6 +220,16 @@ export const unmatched_alert = function () {
           self: "/alerts/338973",
         },
         type: "alert",
+      },
+    ],
+    included: [
+      {
+        attributes: {
+          name: "South Station",
+          location_type: 1,
+        },
+        id: "place-south",
+        type: "stop",
       },
     ],
     jsonapi: {
@@ -173,7 +260,13 @@ export const many_alerts = function () {
               activities: ["USING_WHEELCHAIR"],
               facility: "850",
               stop: "place-north",
-              route_type: 0,
+              route: "Orange",
+            },
+            {
+              activities: ["USING_WHEELCHAIR"],
+              facility: "850",
+              stop: "place-north",
+              route: "Green-C",
             },
           ],
           lifecycle: "ONGOING",
@@ -208,8 +301,8 @@ export const many_alerts = function () {
             {
               activities: ["USING_WHEELCHAIR"],
               facility: "850",
-              stop: "70104",
-              route_type: 0,
+              stop: "place-qamnl",
+              route: "Red",
             },
           ],
           lifecycle: "ONGOING",
@@ -225,6 +318,24 @@ export const many_alerts = function () {
           self: "/alerts/338973",
         },
         type: "alert",
+      },
+    ],
+    included: [
+      {
+        attributes: {
+          name: "North Station",
+          location_type: 1,
+        },
+        id: "place-north",
+        type: "stop",
+      },
+      {
+        attributes: {
+          name: "Quincy Adams",
+          location_type: 1,
+        },
+        id: "place-qamnl",
+        type: "stop",
       },
     ],
     jsonapi: {
@@ -255,13 +366,19 @@ export const many_alerts_for_sort = function () {
               activities: ["USING_WHEELCHAIR"],
               facility: "404",
               stop: "nowhere",
-              route_type: null,
+              route: null,
             },
             {
               activities: ["USING_WHEELCHAIR"],
               facility: "850",
               stop: "place-north",
-              route_type: 0,
+              route: "Orange",
+            },
+            {
+              activities: ["USING_WHEELCHAIR"],
+              facility: "850",
+              stop: "place-north",
+              route: "Green-C",
             },
           ],
           lifecycle: "NEW",
@@ -297,7 +414,13 @@ export const many_alerts_for_sort = function () {
               activities: ["USING_WHEELCHAIR"],
               facility: "850",
               stop: "place-north",
-              route_type: 0,
+              route: "Orange",
+            },
+            {
+              activities: ["USING_WHEELCHAIR"],
+              facility: "850",
+              stop: "place-north",
+              route: "Green-C",
             },
           ],
           lifecycle: "ONGOING",
@@ -332,8 +455,8 @@ export const many_alerts_for_sort = function () {
             {
               activities: ["USING_WHEELCHAIR"],
               facility: "850",
-              stop: "70104",
-              route_type: 0,
+              stop: "place-qamnl",
+              route: "Red",
             },
           ],
           lifecycle: "ONGOING",
@@ -368,8 +491,8 @@ export const many_alerts_for_sort = function () {
             {
               activities: ["USING_WHEELCHAIR"],
               facility: "850",
-              stop: "70104",
-              route_type: 0,
+              stop: "place-qamnl",
+              route: "Red",
             },
           ],
           lifecycle: "ONGOING",
@@ -404,8 +527,8 @@ export const many_alerts_for_sort = function () {
             {
               activities: ["USING_WHEELCHAIR"],
               facility: "850",
-              stop: "70105",
-              route_type: 0,
+              stop: "place-qnctr",
+              route: "Red",
             },
           ],
           lifecycle: "ONGOING_UPCOMING",
@@ -440,8 +563,8 @@ export const many_alerts_for_sort = function () {
             {
               activities: ["USING_WHEELCHAIR"],
               facility: "850",
-              stop: "70105",
-              route_type: 0,
+              stop: "place-qnctr",
+              route: "Red",
             },
           ],
           lifecycle: "ONGOING_UPCOMING",
@@ -457,6 +580,32 @@ export const many_alerts_for_sort = function () {
           self: "/alerts/338973",
         },
         type: "alert",
+      },
+    ],
+    included: [
+      {
+        attributes: {
+          name: "North Station",
+          location_type: 1,
+        },
+        id: "place-north",
+        type: "stop",
+      },
+      {
+        attributes: {
+          name: "Quincy Adams",
+          location_type: 1,
+        },
+        id: "place-qamnl",
+        type: "stop",
+      },
+      {
+        attributes: {
+          name: "Quincy Center",
+          location_type: 1,
+        },
+        id: "place-qnctr",
+        type: "stop",
       },
     ],
     jsonapi: {
@@ -487,7 +636,7 @@ export const bus_station_alert = function () {
               activities: ["USING_WHEELCHAIR"],
               facility: "850",
               stop: "place-ER-0115",
-              route_type: 3,
+              route: "1",
             },
           ],
           lifecycle: "ONGOING",
@@ -503,6 +652,72 @@ export const bus_station_alert = function () {
           self: "/alerts/1007380",
         },
         type: "alert",
+      },
+    ],
+    included: [
+      {
+        attributes: {
+          name: "Lynn Commuter Rail",
+          location_type: 1,
+        },
+        id: "place-ER-0115",
+        type: "stop",
+      },
+    ],
+    jsonapi: {
+      version: "1.0",
+    },
+  };
+};
+
+export const unsupported_route_alert = function () {
+  return {
+    data: [
+      {
+        attributes: {
+          active_period: [
+            {
+              end: null,
+              start: "2019-11-12T04:30:00-05:00",
+            },
+          ],
+          banner: null,
+          cause: "UNKNOWN_CAUSE",
+          created_at: "2019-10-21T16:59:16-04:00",
+          description: "example description",
+          effect: "ELEVATOR_CLOSURE",
+          header: "Example header.",
+          informed_entity: [
+            {
+              activities: ["USING_WHEELCHAIR"],
+              facility: "850",
+              stop: "place-harsq",
+              route: "66",
+            },
+          ],
+          lifecycle: "ONGOING",
+          service_effect: "elevator unavailable",
+          severity: 1,
+          short_header: "short header.",
+          timeframe: "ongoing",
+          updated_at: "2019-11-29T09:59:07-05:00",
+          url: null,
+        },
+        id: "999999",
+        links: {
+          self: "/alerts/999999",
+        },
+        type: "alert",
+      },
+    ],
+    included: [
+      {
+        attributes: {
+          name: "Harvard",
+          location_type: 1,
+        },
+        id: "place-harsq",
+        type: "stop",
       },
     ],
     jsonapi: {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -41,8 +41,6 @@ test("if http client gets no alerts responds all lines okay", async () => {
   jest.spyOn(api_client, "get").mockImplementation((url) => {
     if (url.pathname == "/alerts") {
       return Promise.resolve(data.no_alerts());
-    } else if (url.pathname == "/routes") {
-      return Promise.resolve(data.no_station());
     } else return Promise.reject();
   });
 
@@ -53,8 +51,16 @@ test("if http client gets a bus station alert, responds all lines okay", async (
   jest.spyOn(api_client, "get").mockImplementation((url) => {
     if (url.pathname == "/alerts") {
       return Promise.resolve(data.bus_station_alert());
-    } else if (url.pathname == "/routes") {
-      return Promise.resolve(data.no_station());
+    } else return Promise.reject();
+  });
+
+  expect(await call(handler)).toStrictEqual(no_outages);
+});
+
+test("filter out alerts with unsupported routes", async () => {
+  jest.spyOn(api_client, "get").mockImplementation((url) => {
+    if (url.pathname == "/alerts") {
+      return Promise.resolve(data.unsupported_route_alert());
     } else return Promise.reject();
   });
 
@@ -65,13 +71,6 @@ test("render one alert", async () => {
   jest.spyOn(api_client, "get").mockImplementation((url) => {
     if (url.pathname == "/alerts") {
       return Promise.resolve(data.one_alert());
-    } else if (url.pathname == "/routes") {
-      const route = url.searchParams.get("filter[stop]");
-      if (route == data.quincy_adams().included[0].id) {
-        return Promise.resolve(data.quincy_adams());
-      } else {
-        return Promise.resolve(data.no_station());
-      }
     } else return Promise.reject();
   });
 
@@ -89,14 +88,7 @@ test("render one alert", async () => {
 test("render one alert across multiple lines", async () => {
   jest.spyOn(api_client, "get").mockImplementation((url) => {
     if (url.pathname == "/alerts") {
-      return Promise.resolve(data.one_alert());
-    } else if (url.pathname == "/routes") {
-      const route = url.searchParams.get("filter[stop]");
-      if (route == data.north_station().included[0].id) {
-        return Promise.resolve(data.north_station());
-      } else {
-        return Promise.resolve(data.no_station());
-      }
+      return Promise.resolve(data.one_alert_multiple_lines());
     } else return Promise.reject();
   });
 
@@ -115,15 +107,6 @@ test("render multiple alerts across multiple lines", async () => {
   jest.spyOn(api_client, "get").mockImplementation((url) => {
     if (url.pathname == "/alerts") {
       return Promise.resolve(data.many_alerts());
-    } else if (url.pathname == "/routes") {
-      const route = url.searchParams.get("filter[stop]");
-      if (route == data.north_station().included[0].id) {
-        return Promise.resolve(data.north_station());
-      } else if (route == data.quincy_adams().included[0].id) {
-        return Promise.resolve(data.quincy_adams());
-      } else {
-        return Promise.resolve(data.no_station());
-      }
     } else return Promise.reject();
   });
 
@@ -142,57 +125,16 @@ test("only show alerts for elevator or escalator closure", async () => {
   jest.spyOn(api_client, "get").mockImplementation((url) => {
     if (url.pathname == "/alerts") {
       return Promise.resolve(data.not_alert());
-    } else if (url.pathname == "/routes") {
-      const route = url.searchParams.get("filter[stop]");
-      if (route == data.north_station().included[0].id) {
-        return Promise.resolve(data.north_station());
-      } else {
-        return Promise.resolve(data.no_station());
-      }
     } else return Promise.reject();
   });
 
   expect(await call(handler)).toStrictEqual(no_outages);
-});
-
-test("warn on unmatched alert, but still return correctly", async () => {
-  console.log = jest.fn();
-  jest.spyOn(api_client, "get").mockImplementation((url) => {
-    if (url.pathname == "/alerts") {
-      return Promise.resolve(data.unmatched_alert());
-    } else if (url.pathname == "/routes") {
-      const route = url.searchParams.get("filter[stop]");
-      if (route == data.north_station().included[0].id) {
-        return Promise.resolve(data.north_station());
-      } else {
-        return Promise.resolve(data.no_station());
-      }
-    } else return Promise.reject();
-  });
-
-  expect(await call(handler)).toStrictEqual(no_outages);
-  expect(console.log).toHaveBeenCalledWith(
-    'Error: Alert for a station not in routes {"id":"338974","type":"escalator closure","lifecycle":"ONGOING","description":"Example header. . example description <break time=\\"1s\\"/>","entities":["place-south"],"updatedAt":1575039547000}'
-  );
 });
 
 test("sorts multiple alerts across multiple lines correctly", async () => {
   jest.spyOn(api_client, "get").mockImplementation((url) => {
     if (url.pathname == "/alerts") {
       return Promise.resolve(data.many_alerts_for_sort());
-    } else if (url.pathname == "/routes") {
-      const route = url.searchParams.get("filter[stop]");
-      if (route == data.north_station().included[0].id) {
-        return Promise.resolve(data.north_station());
-      } else if (route == data.quincy_adams().included[0].id) {
-        return Promise.resolve(data.quincy_adams());
-      } else if (route == data.nowhere().included[0].id) {
-        return Promise.resolve(data.nowhere());
-      } else if (route == data.quincy_center().included[0].id) {
-        return Promise.resolve(data.quincy_center());
-      } else {
-        return Promise.resolve(data.no_station());
-      }
     } else return Promise.reject();
   });
 


### PR DESCRIPTION
**Asana task:** [Investigate Elevator Hotline failure alerts](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1213963824351555?focus=true)

The Lambda is exceeding the 8 second max invocation time from AWS Connect on cold starts. This refactor speeds up the Lambda by about ~1.5-2 seconds from local testing by doing the following:

1. Include stops when fetching alerts
2. Tie each relevant alert to a list of unique affected Line and parent station combos. This covers the case in which an elevator is at a transfer station and affects multiple lines.
3. Remove the multiple API calls to fetch route information entirely 

This PR also includes general cleanup of the code. Still much that could be improved, but don't want this to get too out of hand.