### PR TITLE
chore(typescript): set types field in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@tsconfig/node24",
   "compilerOptions": {
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   }
 }


### PR DESCRIPTION


**Asana task:** N/A

### Summary

Explicitly set the `types` field in `tsconfig.json`. Both https://github.com/mbta/elevator_hotline/pull/127 and https://github.com/mbta/elevator_hotline/pull/126 are failing our CI's typecheck step, which is the impetus for the commit.

It has been verified that `master` type checks correctly (i.e. the current state of the repo still type checks OK). Recent changes to tsx and esbuild have been explicitly ruled out as well, by reverting those commits locally (and remotely), where we are seeing the same behavior.

The version of TypeScript has been verified in CI to match that of the lockfile.

The leading cause behind this issue is believed to involve `@sentry/node`, which is updated in both PRs. While `@types/node` is still found in our `package-lock` file, something is causing said types to not resolve correctly. Until `tsconfig/node24` is updated to include `@types/node` by default, this shall unblock said Dependabot updates.

### Notes for Reviewers

- We could dig further into this, but I felt that the value/time tradeoff didn't merit sinking more than 20 minutes into this. If you have further thoughts/alternative solutions, happy to pivot 
- When both of the aforementioned PRs are rebased atop this commit, this pass typechecking
- I thought that I would end my day with a few easy Dependabot PRs, and here we are 😆 