### PR TITLE
chore(ci): replace mbta/actions/reshim-asdf

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,15 @@ runs:
     - uses: asdf-vm/actions/install@v4
       if: steps.asdf-cache.outputs.cache-hit != 'true'
 
-    - uses: mbta/actions/reshim-asdf@v2
+    - name: Setup ASDF environment
+      uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
+      with:
+        skip_install: true
+      if: steps.asdf-cache.outputs.cache-hit == 'true'
+
+    - name: Reshim ASDF
+      shell: bash
+      run: asdf reshim
       if: steps.asdf-cache.outputs.cache-hit == 'true'
 
     - uses: actions/cache@v6.1.0


### PR DESCRIPTION


**Asana task:** N/A
### Summary
Replace `mbta/actions/reshim-asdf` with `asdf-vm/actions/setup`. In the v2.20 release of the former, commit mbta/actions@3579cb7 marked the `reshim-asdf` action as deprecated. A recent Dependabot update attempted to bump this action's version to v2.20 - while the update would succeed otherwise, replace the action now while it's on top of mind.

Supersedes: https://github.com/mbta/elevator_hotline/pull/141