### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
+    groups:
+      github-actions-minor:
+        update-types:
+          - "patch"
+          - "minor"
   - package-ecosystem: npm
     directory: "/"
     schedule:


### PR DESCRIPTION


**Asana task:** N/A

### Summary
In the 2026.07.07 retro, we commented that the number of individual PRs was getting high. This commit attempts to cut down on the noise by grouping updates of all actions for minor/patch versions, similar to other ecosystems in this repo